### PR TITLE
Adding admin functionality

### DIFF
--- a/auth/admin.py
+++ b/auth/admin.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python3.6
+
+import json
+from oidc_auth import DEFAULT_AUTH_FILE_LOCATION
+
+BLACKLIST_FILE = "/etc/ugr/conf.d/blacklist.json"
+
+def get_buckets():
+    with open(DEFAULT_AUTH_FILE_LOCATION, "r") as f:
+        auth_dict = json.load(f)
+    
+    bucket_dict = {}
+
+    for group in auth_dict["groups"]:
+        group_name = group["name"]
+        buckets = []
+        
+        for bucket in group["buckets"]:
+            bucket_name = bucket["name"]
+            buckets.append(bucket_name)
+
+        bucket_dict[group_name] = buckets
+
+    return bucket_dict
+
+def blacklist_bucket(bucket_name):
+    try:
+        with open(BLACKLIST_FILE, "r") as f:
+            blacklist = json.load(f)
+    except FileNotFoundError:
+        blacklist = {"buckets": []}
+
+    if bucket_name not in blacklist["buckets"]:
+        blacklist["buckets"].append(bucket_name)
+
+    with open(BLACKLIST_FILE, "w") as f:
+        json.dump(blacklist, f, indent=4)
+
+def whitelist_bucket(bucket_name):
+    try:
+        with open(BLACKLIST_FILE, "r") as f:
+            blacklist = json.load(f)
+    except FileNotFoundError:
+        file_json = {"buckets": []}
+        with open(BLACKLIST_FILE, "w") as f:
+            json.dump(file_json, indent=4)
+            return
+
+    if bucket_name in blacklist["buckets"]:
+        blacklist["buckets"].remove(bucket_name)
+
+        with open(BLACKLIST_FILE, "w") as f:
+            json.dump(blacklist, f, indent=4)
+
+def get_blacklist():
+    try:
+        with open(BLACKLIST_FILE, "r") as f:
+            blacklist = json.load(f)
+    except FileNotFoundError:
+        return []
+
+    buckets = []
+    for bucket in blacklist["buckets"]:
+        buckets.append(bucket)
+    return buckets
+    

--- a/auth/blacklisting.py
+++ b/auth/blacklisting.py
@@ -11,8 +11,7 @@ def add_to_blacklist(args):
         if not admin_operation:
             return 1
 
-        res_get = sync.get()
-        if res_get != 0:
+        if sync.get() != 0:
             return 2
         
         try:
@@ -27,7 +26,9 @@ def add_to_blacklist(args):
             with open(BLACKLIST_FILE, "w") as f:
                 json.dump(blacklist, f, indent=4)
 
-            return sync.put()
+            if sync.put() != 0:
+                return 2
+            return 0
         else:
             return 3
     else:
@@ -41,8 +42,7 @@ def remove_from_blacklist(args):
         if not admin_operation:
             return 1
 
-        res_get = sync.get()
-        if res_get != 0:
+        if sync.get() != 0:
             return 2
 
         try:
@@ -60,7 +60,9 @@ def remove_from_blacklist(args):
             with open(BLACKLIST_FILE, "w") as f:
                 json.dump(blacklist, f, indent=4)
 
-            return sync.put()
+            if sync.put() != 0:
+                return 2
+            return 0
         else:
             return 3
     else:

--- a/auth/blacklisting.py
+++ b/auth/blacklisting.py
@@ -1,38 +1,63 @@
 #!/usr/bin/python3.6
 
 import json
-from oidc_auth import DEFAULT_AUTH_FILE_LOCATION
 
 BLACKLIST_FILE = "/etc/ugr/conf.d/blacklist.json"
 
-def blacklist_bucket(bucket_name):
-    try:
-        with open(BLACKLIST_FILE, "r") as f:
-            blacklist = json.load(f)
-    except FileNotFoundError:
-        blacklist = {"buckets": []}
+def add_to_blacklist(args):
 
-    if bucket_name not in blacklist["buckets"]:
-        blacklist["buckets"].append(bucket_name)
+    if (args.bucket is not None and args.admin_operation is not None and args.groups is not None):
+        admin_operation = args.admin_operation and "dynafed/admins" in args.groups
 
-    with open(BLACKLIST_FILE, "w") as f:
-        json.dump(blacklist, f, indent=4)
+        if not admin_operation:
+            return 1
 
-def whitelist_bucket(bucket_name):
-    try:
-        with open(BLACKLIST_FILE, "r") as f:
-            blacklist = json.load(f)
-    except FileNotFoundError:
-        file_json = {"buckets": []}
-        with open(BLACKLIST_FILE, "w") as f:
-            json.dump(file_json, indent=4)
-            return
+        try:
+            with open(BLACKLIST_FILE, "r") as f:
+                blacklist = json.load(f)
+        except FileNotFoundError:
+            blacklist = {"buckets": []}
 
-    if bucket_name in blacklist["buckets"]:
-        blacklist["buckets"].remove(bucket_name)
+        if args.bucket not in blacklist["buckets"]:
+            blacklist["buckets"].append(args.bucket)
 
         with open(BLACKLIST_FILE, "w") as f:
             json.dump(blacklist, f, indent=4)
+
+            return 0
+        else:
+            return 2
+    else:
+        return 1
+
+def remove_from_blacklist(args):
+
+    if (args.bucket is not None and args.admin_operation is not None and args.groups is not None):
+        admin_operation = args.admin_operation and "dynafed/admins" in args.groups
+
+        if not admin_operation:
+            return 1
+
+        try:
+            with open(BLACKLIST_FILE, "r") as f:
+                blacklist = json.load(f)
+        except FileNotFoundError:
+            file_json = {"buckets": []}
+            with open(BLACKLIST_FILE, "w") as f:
+                json.dump(file_json, indent=4)
+                return
+
+        if args.bucket in blacklist["buckets"]:
+            blacklist["buckets"].remove(args.bucket)
+
+            with open(BLACKLIST_FILE, "w") as f:
+                json.dump(blacklist, f, indent=4)
+
+            return 0
+        else:
+            return 2
+    else:
+        return 1
 
 def get_blacklist():
     try:

--- a/auth/blacklisting.py
+++ b/auth/blacklisting.py
@@ -5,24 +5,6 @@ from oidc_auth import DEFAULT_AUTH_FILE_LOCATION
 
 BLACKLIST_FILE = "/etc/ugr/conf.d/blacklist.json"
 
-def get_buckets():
-    with open(DEFAULT_AUTH_FILE_LOCATION, "r") as f:
-        auth_dict = json.load(f)
-    
-    bucket_dict = {}
-
-    for group in auth_dict["groups"]:
-        group_name = group["name"]
-        buckets = []
-        
-        for bucket in group["buckets"]:
-            bucket_name = bucket["name"]
-            buckets.append(bucket_name)
-
-        bucket_dict[group_name] = buckets
-
-    return bucket_dict
-
 def blacklist_bucket(bucket_name):
     try:
         with open(BLACKLIST_FILE, "r") as f:
@@ -59,8 +41,5 @@ def get_blacklist():
     except FileNotFoundError:
         return []
 
-    buckets = []
-    for bucket in blacklist["buckets"]:
-        buckets.append(bucket)
-    return buckets
+    return blacklist["buckets"]
     

--- a/auth/blacklisting.py
+++ b/auth/blacklisting.py
@@ -1,17 +1,20 @@
 #!/usr/bin/python3.6
 
 import json
-
-BLACKLIST_FILE = "/etc/ugr/conf.d/blacklist.json"
+import sync
+from oidc_auth import BLACKLIST_FILE
 
 def add_to_blacklist(args):
-
     if (args.bucket is not None and args.admin_operation is not None and args.groups is not None):
         admin_operation = args.admin_operation and "dynafed/admins" in args.groups
 
         if not admin_operation:
             return 1
 
+        res_get = sync.get()
+        if res_get != 0:
+            return 2
+        
         try:
             with open(BLACKLIST_FILE, "r") as f:
                 blacklist = json.load(f)
@@ -21,12 +24,12 @@ def add_to_blacklist(args):
         if args.bucket not in blacklist["buckets"]:
             blacklist["buckets"].append(args.bucket)
 
-        with open(BLACKLIST_FILE, "w") as f:
-            json.dump(blacklist, f, indent=4)
+            with open(BLACKLIST_FILE, "w") as f:
+                json.dump(blacklist, f, indent=4)
 
-            return 0
+            return sync.put()
         else:
-            return 2
+            return 3
     else:
         return 1
 
@@ -37,6 +40,10 @@ def remove_from_blacklist(args):
 
         if not admin_operation:
             return 1
+
+        res_get = sync.get()
+        if res_get != 0:
+            return 2
 
         try:
             with open(BLACKLIST_FILE, "r") as f:
@@ -53,9 +60,9 @@ def remove_from_blacklist(args):
             with open(BLACKLIST_FILE, "w") as f:
                 json.dump(blacklist, f, indent=4)
 
-            return 0
+            return sync.put()
         else:
-            return 2
+            return 3
     else:
         return 1
 

--- a/auth/manage_config.py
+++ b/auth/manage_config.py
@@ -13,6 +13,7 @@ import boto3
 from botocore.exceptions import ClientError
 from oidc_auth import DEFAULT_AUTH_FILE_LOCATION
 import sync
+import blacklisting
 
 
 # needed for python 2 and 3 compabilility to check str types	
@@ -623,6 +624,9 @@ def import_bucket(args):
     if res_get != 0:
         return 4
 
+    if args.bucket in blacklisting.get_blacklist():
+        return 5
+
     # check config file is valid first
     args.suppress_verify_output = True
     if verify(args) != 0:
@@ -643,7 +647,7 @@ def import_bucket(args):
 
     res_put = sync.put()
     if res_put != 0:
-        return 5
+        return 4
 
     res_get = sync.get()
     if res_get != 0:
@@ -664,14 +668,14 @@ def remove_bucket(args):
     res_get = sync.get()
     if res_get != 0:
         return 4
-
+    
     args.suppress_verify_output = True
     if verify(args) != 0:
         # restore stdout
         sys.stdout = sys.__stdout__
         print("Config file not valid, please use the verify function to debug")
         return 1
-
+    
     if does_bucket_exist(args) != 0:
         return 2
 
@@ -682,22 +686,22 @@ def remove_bucket(args):
     #entry that doesn't exist. Not sure how to get around this while keeping the key validation in place
     #TL;DR not a massive issue but still annoying
 
-    if (args.admin_operation is not None and args.groups is not None):
+    if hasattr(args, 'admin_operation') and hasattr(args, 'groups'):
         admin_operation = args.admin_operation and "dynafed/admins" in args.groups
-
+        
         if not admin_operation:
             # Validate bucket exists in Echo
             if update_bucket_cors(args) != 0:
                 return 3
-    else:
-        update_bucket_cors(args)
+    elif update_bucket_cors(args) != 0:
+            return 3
 
     remove_bucket_from_config_file(args)
     remove_bucket_from_json(args)
 
     res_put = sync.put()
     if res_put != 0:
-        return 5
+        return 4
 
     res_get = sync.get()
     if res_get != 0:

--- a/auth/manage_config.py
+++ b/auth/manage_config.py
@@ -679,7 +679,7 @@ def remove_bucket(args):
     if does_bucket_exist(args) != 0:
         return 2
 
-    #TODO potential issue with this. We need to validate the bucket keys are correct and this is how we do it
+    #Potential issue: we need to validate the bucket keys are correct and this is how we do it
     #However, issue with this occurs if the bucket no longer exists in Echo. This currently prevents it from being
     #removed as an entry in DynaFed. 
     #Potential solution: if we are an admin, bypass this keys check. This would mean the user cannot remove a bucket

--- a/auth/manage_config.py
+++ b/auth/manage_config.py
@@ -682,12 +682,15 @@ def remove_bucket(args):
     #entry that doesn't exist. Not sure how to get around this while keeping the key validation in place
     #TL;DR not a massive issue but still annoying
 
-    admin_operation = args.admin_operation and "dynafed/admins" in args.groups
+    if (args.admin_operation is not None and args.groups is not None):
+        admin_operation = args.admin_operation and "dynafed/admins" in args.groups
 
-    if not admin_operation:
-        # Validate bucket exists in Echo
-        if update_bucket_cors(args) != 0:
-            return 3
+        if not admin_operation:
+            # Validate bucket exists in Echo
+            if update_bucket_cors(args) != 0:
+                return 3
+    else:
+        update_bucket_cors(args)
 
     remove_bucket_from_config_file(args)
     remove_bucket_from_json(args)

--- a/auth/oidc_auth.py
+++ b/auth/oidc_auth.py
@@ -21,7 +21,6 @@
 import sys
 import json
 import time
-#import blacklisting
 
 DEFAULT_AUTH_FILE_LOCATION = "/etc/grid-security/oidc_auth.json"
 BLACKLIST_FILE = "/etc/ugr/conf.d/blacklist.json"

--- a/auth/oidc_auth.py
+++ b/auth/oidc_auth.py
@@ -139,6 +139,9 @@ def isallowed(clientname="unknown", remoteaddr="nowhere", resource="none", mode=
         user_info["http.OIDC_CLAIM_groups"] = user_info["http.OIDC_CLAIM_groups"].split(
             ",")
 
+    if "dynafed/admins" in user_info["http.OIDC_CLAIM_groups"]:
+        return 0
+
     myauthjson = _AuthJSON()
     result = myauthjson.auth_info_for_path(resource)
     if result is None:

--- a/auth/oidc_auth.py
+++ b/auth/oidc_auth.py
@@ -149,8 +149,8 @@ def isallowed(clientname="unknown", remoteaddr="nowhere", resource="none", mode=
         user_info["http.OIDC_CLAIM_groups"] = user_info["http.OIDC_CLAIM_groups"].split(
             ",")
 
-    #if "dynafed/admins" in user_info["http.OIDC_CLAIM_groups"]:
-    #    return 0
+    if "dynafed/admins" in user_info["http.OIDC_CLAIM_groups"]:
+       return 0
 
     myauthjson = _AuthJSON()
     result = myauthjson.auth_info_for_path(resource)

--- a/auth/sync.py
+++ b/auth/sync.py
@@ -94,6 +94,8 @@ def get():
 
         if key == 'oidc_auth.json':     # authorisation rules file
             filepath = '/etc/grid-security/' + key
+        elif key == 'blacklist.json':     # blacklist file
+            filepath = '/etc/ugr/conf.d/' + key
 
         try:
             obj = conn.get_object(Bucket=BUCKET_NAME, Key=key)
@@ -148,6 +150,14 @@ def put():
     except FileNotFoundError:
         print("Error: could not find or open /etc/grid-security/oidc_auth.json. File does not exist!")
         return 1
+
+    blacklist_json = '/etc/ugr/conf.d/blacklist.json'
+    key = ntpath.basename(blacklist_json)
+
+    try:
+        conn.put_object(Body=open(blacklist_json, 'rb'), Bucket=BUCKET_NAME, Key=key)
+    except FileNotFoundError:
+        print("Warning: no blacklist file at /etc/ugr/conf.d/blacklist.json.")
 
     return 0
 

--- a/auth/sync.py
+++ b/auth/sync.py
@@ -106,6 +106,8 @@ def get():
         with open(filepath, 'w') as f:
             f.write(obj['Body'].read().decode('utf-8'))
         os.chown(filepath, uid, gid)        # change owner of file to apache so it can be amended later through the web UI if necessary
+        if key == 'oidc_auth.json' or key == 'blacklist.json':
+            os.chmod(filepath, 0o646)       # JSON files need 646 permissions to be read from and written to by our Python scripts
 
     # Deleting .conf files not in bucket
     allfiles = [f for f in os.listdir('/etc/ugr/conf.d/') if os.path.isfile(os.path.join('/etc/ugr/conf.d', f))]

--- a/cgi-bin/add_to_blacklist.py
+++ b/cgi-bin/add_to_blacklist.py
@@ -18,8 +18,9 @@ from blacklisting import add_to_blacklist
 RETURN_CODES = {
     0: 'Status: 201 success',
     1: 'Status: 403 unauthorised',
-    2: 'Status 409 resource exists',
-    3: 'Status: 400 bad request'
+    2: 'Status: 500 cannot synchronise files',
+    3: 'Status: 409 resource exists',
+    4: 'Status: 400 bad request'
 }
 
 # Create instance of FieldStorage 
@@ -36,5 +37,5 @@ if form.getvalue('bucket') and form.getvalue('groups[]') and form.getvalue('admi
     result = add_to_blacklist(args)
     print(RETURN_CODES[result])
 else:
-    print(RETURN_CODES[2])
+    print(RETURN_CODES[3])
 print()

--- a/cgi-bin/add_to_blacklist.py
+++ b/cgi-bin/add_to_blacklist.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3.6
+
+"""
+Receives information via POST from IRIS DynaFed web UI for adding a bucket to blacklist
+Sends it off to blacklisting.py
+"""
+
+# Import modules for CGI handling 
+import cgi 
+import argparse
+import sys
+
+CONFIG_PATH = "/etc/ugr/conf.d/"
+sys.path.append(CONFIG_PATH)
+
+from blacklisting import add_to_blacklist
+
+RETURN_CODES = {
+    0: 'Status: 201 success',
+    1: 'Status: 403 unauthorised',
+    2: 'Status 409 resource exists',
+    3: 'Status: 400 bad request'
+}
+
+# Create instance of FieldStorage 
+form = cgi.FieldStorage() 
+
+# Get data from POST fields
+if form.getvalue('bucket') and form.getvalue('groups[]') and form.getvalue('admin_operation'):
+    bucket = form.getvalue('bucket')
+    groups = form.getvalue('groups[]')
+    admin_operation = form.getvalue('admin_operation')
+
+    args = argparse.Namespace(bucket=bucket, groups=groups, admin_operation=admin_operation)
+
+    result = add_to_blacklist(args)
+    print(RETURN_CODES[result])
+else:
+    print(RETURN_CODES[2])
+print()

--- a/cgi-bin/add_to_blacklist.py
+++ b/cgi-bin/add_to_blacklist.py
@@ -37,5 +37,5 @@ if form.getvalue('bucket') and form.getvalue('groups[]') and form.getvalue('admi
     result = add_to_blacklist(args)
     print(RETURN_CODES[result])
 else:
-    print(RETURN_CODES[3])
+    print(RETURN_CODES[4])
 print()

--- a/cgi-bin/get_blacklist.py
+++ b/cgi-bin/get_blacklist.py
@@ -1,0 +1,24 @@
+#!/usr/bin/python3.6
+
+"""
+Return a list of all groups
+"""
+
+import json
+import sys
+
+CONFIG_PATH = "/etc/ugr/conf.d/"
+sys.path.append(CONFIG_PATH)
+
+from blacklisting import get_blacklist
+
+buckets = get_blacklist()
+buckets = sorted(buckets)
+body = json.dumps(buckets)
+
+print("Status: 200 OK")
+print("Content-Type: application/json")
+print("Content-Length: {}".format(len(body)))
+print("")
+print(body)
+print()

--- a/cgi-bin/get_groups.py
+++ b/cgi-bin/get_groups.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python3.6
+
+"""
+Return a list of all groups
+"""
+
+import json
+import sys
+import argparse
+
+CONFIG_PATH = "/etc/ugr/conf.d/"
+sys.path.append(CONFIG_PATH)
+
+from manage_config import get_groups
+
+args = argparse.Namespace(file='/etc/grid-security/oidc_auth.json')
+groups = get_groups(args)
+groups = [g.replace('-', '/') for g in groups]
+groups = [str(g) for g in groups]
+groups = sorted(groups)
+body = json.dumps(groups)
+
+print("Status: 200 OK")
+print("Content-Type: application/json")
+print("Content-Length: {}".format(len(body)))
+print("")
+print(body)
+print()

--- a/cgi-bin/import.py
+++ b/cgi-bin/import.py
@@ -6,7 +6,7 @@ Sends it off to manage_config.py
 """
 
 # Import modules for CGI handling 
-import cgi, cgitb 
+import cgi 
 import argparse
 import sys
 

--- a/cgi-bin/import.py
+++ b/cgi-bin/import.py
@@ -20,8 +20,9 @@ RETURN_CODES = {
     1: 'Status: 500 authorisation config error',
     2: 'Status: 409 bucket already exists in IRIS DynaFed',
     3: 'Status: 404 bucket does not exist in Echo',
-    4: 'Status: 500, cannot synchronise files',
-    5: 'Status: 500, cannot synchronise files'
+    4: 'Status: 500 cannot synchronise files',
+    5: 'Status: 403 bucket is blacklisted',
+    6: 'Status: 400 invalid client request'
 }
 
 # Create instance of FieldStorage 
@@ -50,5 +51,5 @@ if form.getvalue('group') and form.getvalue('bucket') and form.getvalue('public_
     result = import_bucket(args)
     print(RETURN_CODES[result])
 else:
-    print('Status: 400 bad request')
+    print(RETURN_CODES[6])
 print()

--- a/cgi-bin/remove.py
+++ b/cgi-bin/remove.py
@@ -28,13 +28,17 @@ RETURN_CODES = {
 form = cgi.FieldStorage() 
 
 # Get data from POST fields
-if form.getvalue('group') and form.getvalue('bucket') and form.getvalue('public_key') and form.getvalue('private_key'):
+if form.getvalue('group') and form.getvalue('bucket') and form.getvalue('public_key') and form.getvalue('private_key') and form.getvalue('groups') and form.getvalue('admin_operation'):
     group = form.getvalue('group')
     bucket = form.getvalue('bucket')
     public_key = form.getvalue('public_key')
     private_key = form.getvalue('private_key')
 
-    args = argparse.Namespace(group=group, bucket=bucket, public_key=public_key, private_key=private_key, file="/etc/grid-security/oidc_auth.json")
+    # Used for admin purposes. This allows for a bucket removal being performed by an admin to be verified. Ensure they are a member of dynafed/admins AND they're performing the removal request as an admin
+    groups = form.getvalue('groups')
+    admin_operation = form.getvalue('admin_operation')
+
+    args = argparse.Namespace(group=group, bucket=bucket, public_key=public_key, private_key=private_key, groups=groups, admin_operation=admin_operation, file="/etc/grid-security/oidc_auth.json")
 
     result = remove_bucket(args)
     print(RETURN_CODES[result])

--- a/cgi-bin/remove.py
+++ b/cgi-bin/remove.py
@@ -20,9 +20,8 @@ RETURN_CODES = {
     1: 'Status: 500 authorisation config error',
     2: 'Status: 409 bucket does not exist in IRIS DynaFed',
     3: 'Status: 404 bucket does not exist in Echo',
-    4: 'Status: 500, cannot synchronise files',
-    5: 'Status: 500, cannot synchronise files',
-    6: 'Status: 400, invalid client request'
+    4: 'Status: 500 cannot synchronise files',
+    5: 'Status: 400 invalid client request'
 }
 
 # Create instance of FieldStorage 
@@ -43,12 +42,12 @@ if form.getvalue('group') and form.getvalue('bucket'):
         private_key = form.getvalue('private_key')
         args = argparse.Namespace(group=group, bucket=bucket, public_key=public_key, private_key=private_key, file="/etc/grid-security/oidc_auth.json")
     else:
-        print(RETURN_CODES[6])
+        print(RETURN_CODES[5])
         print()
         sys.exit(0)
 
     result = remove_bucket(args)
     print(RETURN_CODES[result])
 else:
-    print(RETURN_CODES[6])
+    print(RETURN_CODES[5])
 print()

--- a/cgi-bin/remove.py
+++ b/cgi-bin/remove.py
@@ -6,7 +6,7 @@ Sends it off to manage_config.py
 """
 
 # Import modules for CGI handling 
-import cgi, cgitb 
+import cgi 
 import argparse
 import sys
 
@@ -21,27 +21,34 @@ RETURN_CODES = {
     2: 'Status: 409 bucket does not exist in IRIS DynaFed',
     3: 'Status: 404 bucket does not exist in Echo',
     4: 'Status: 500, cannot synchronise files',
-    5: 'Status: 500, cannot synchronise files'
+    5: 'Status: 500, cannot synchronise files',
+    6: 'Status: 400, invalid client request'
 }
 
 # Create instance of FieldStorage 
 form = cgi.FieldStorage() 
 
 # Get data from POST fields
-if form.getvalue('group') and form.getvalue('bucket') and form.getvalue('public_key') and form.getvalue('private_key') and form.getvalue('groups') and form.getvalue('admin_operation'):
+if form.getvalue('group') and form.getvalue('bucket'):
     group = form.getvalue('group')
     bucket = form.getvalue('bucket')
-    public_key = form.getvalue('public_key')
-    private_key = form.getvalue('private_key')
 
-    # Used for admin purposes. This allows for a bucket removal being performed by an admin to be verified. Ensure they are a member of dynafed/admins AND they're performing the removal request as an admin
-    groups = form.getvalue('groups')
-    admin_operation = form.getvalue('admin_operation')
-
-    args = argparse.Namespace(group=group, bucket=bucket, public_key=public_key, private_key=private_key, groups=groups, admin_operation=admin_operation, file="/etc/grid-security/oidc_auth.json")
+    if form.getvalue('groups[]') and form.getvalue('admin_operation'):
+        # Used for admin purposes. This allows for a bucket removal being performed by an admin to be verified. Ensure they are a member of dynafed/admins AND they're performing the removal request as an admin
+        groups = form.getvalue('groups[]')
+        admin_operation = form.getvalue('admin_operation')
+        args = argparse.Namespace(group=group, bucket=bucket, groups=groups, admin_operation=admin_operation, file="/etc/grid-security/oidc_auth.json")
+    elif form.getvalue('public_key') and form.getvalue('private_key'):
+        public_key = form.getvalue('public_key')
+        private_key = form.getvalue('private_key')
+        args = argparse.Namespace(group=group, bucket=bucket, public_key=public_key, private_key=private_key, file="/etc/grid-security/oidc_auth.json")
+    else:
+        print(RETURN_CODES[6])
+        print()
+        sys.exit(0)
 
     result = remove_bucket(args)
     print(RETURN_CODES[result])
 else:
-    print('Status: 400 bad request')
+    print(RETURN_CODES[6])
 print()

--- a/cgi-bin/remove_from_blacklist.py
+++ b/cgi-bin/remove_from_blacklist.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python3.6
+
+"""
+Receives information via POST from IRIS DynaFed web UI for removing a bucket from blacklist
+Sends it off to blacklisting.py
+"""
+
+# Import modules for CGI handling 
+import cgi 
+import argparse
+import sys
+
+CONFIG_PATH = "/etc/ugr/conf.d/"
+sys.path.append(CONFIG_PATH)
+
+from blacklisting import remove_from_blacklist
+
+RETURN_CODES = {
+    0: 'Status: 204 success',
+    1: 'Status: 403 unauthorised',
+    2: 'Status: 409 resource does not exist',
+    3: 'Status: 400 bad request'
+}
+
+# Create instance of FieldStorage 
+form = cgi.FieldStorage() 
+
+# Get data from POST fields
+if form.getvalue('bucket') and form.getvalue('groups[]') and form.getvalue('admin_operation'):
+    bucket = form.getvalue('bucket')
+    groups = form.getvalue('groups[]')
+    admin_operation = form.getvalue('admin_operation')
+
+    args = argparse.Namespace(bucket=bucket, groups=groups, admin_operation=admin_operation)
+
+    result = remove_from_blacklist(args)
+    print(RETURN_CODES[result])
+else:
+    print(RETURN_CODES[2])
+print()

--- a/cgi-bin/remove_from_blacklist.py
+++ b/cgi-bin/remove_from_blacklist.py
@@ -37,5 +37,5 @@ if form.getvalue('bucket') and form.getvalue('groups[]') and form.getvalue('admi
     result = remove_from_blacklist(args)
     print(RETURN_CODES[result])
 else:
-    print(RETURN_CODES[3])
+    print(RETURN_CODES[4])
 print()

--- a/cgi-bin/remove_from_blacklist.py
+++ b/cgi-bin/remove_from_blacklist.py
@@ -18,8 +18,9 @@ from blacklisting import remove_from_blacklist
 RETURN_CODES = {
     0: 'Status: 204 success',
     1: 'Status: 403 unauthorised',
-    2: 'Status: 409 resource does not exist',
-    3: 'Status: 400 bad request'
+    2: 'Status: 500 cannot synchronise files',
+    3: 'Status: 409 resource does not exist',
+    4: 'Status: 400 bad request'
 }
 
 # Create instance of FieldStorage 
@@ -36,5 +37,5 @@ if form.getvalue('bucket') and form.getvalue('groups[]') and form.getvalue('admi
     result = remove_from_blacklist(args)
     print(RETURN_CODES[result])
 else:
-    print(RETURN_CODES[2])
+    print(RETURN_CODES[3])
 print()


### PR DESCRIPTION
This includes:

- blacklisting of buckets by server admins. This allows for admins to maintain a blacklist.json file in /etc/ugr/conf.d/, which is synchronised with the other .conf files in the Echo bucket. They can add to it and remove from it using additional cgi-scripts add_to_blacklist.py and remove_from_blacklist.py
- amendments of manage_config.py and oidc_auth.py to account for blacklist. If user is importing a bucket, the bucket name is checked against the blacklist. If it's on there, an error 403 is sent back to the frontend to inform the user. oidc_auth.py is also amended to check if a bucket a user is accessing is in the blacklist. If so, deny access. This is needed for when a bucket is blacklisted and remains assigned to a group, ensuring they can't access it. It is best for them or an admin to remove the bucket themselves
- amendment of sync.py to include blacklist.json in the files it uploads and downloads from Echo
- amendment of manage_config.py to allow for admins to remove buckets from any group without requiring the keys to that bucket. This also amends cgi-bin/remove.py to account for this
- additional scripts cgi-bin/get_blacklist.py and cgi-bin/get_groups.py. get_blacklist is for admins to view the blacklist front-end. get_groups is for admins to select from a dropdown list the group they want to remove a bucket from